### PR TITLE
0.3.7: Clearer and more foolproof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+#/Projects/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "brci_interface"
-version = "0.1.0"
+version = "0.3.7"
 dependencies = [
  "to-binary",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brci_interface"
-version = "0.1.0"
+version = "0.3.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,24 +1,45 @@
 #[allow(unused_imports)]
-use std::fs::{File, copy, create_dir_all};
+use std::fs::{File, copy, create_dir_all, remove_file};
+use std::path::Path;
+
+use crate::misc::FM;
+// tell rust that 'misc' is in src/misc/mod.rs
+
 // use std::io::Write;
 
-#[allow(dead_code)]
-pub fn write_brv() {
+#[allow(unused_variables)]
+pub fn write_brv(project_path: &str) -> std::io::Result<()> {
     // ...
+    Ok(())
 }
 
-#[allow(dead_code)]
+#[allow(unused_variables)]
 pub fn write_preview(project_path: &str) -> std::io::Result<()> {
     // We need to clone BRCI_preview.png.
     copy("BRCI_preview.png", format!("{}/Preview.png", project_path))?;
     Ok(())
 }
 
+#[allow(unused_variables)]
+pub fn write_brm(project_path: &str) -> std::io::Result<()> {
+    // ...
+    Ok(())
+}
+
 #[allow(dead_code)]
 pub fn make_project(project_name: &str, project_directory: &str) -> std::io::Result<()> {
-    let project_path = format!("{}/{}", project_directory, project_name);
-    create_dir_all(&project_path)?;
-    write_brv();
+    let project_path: String = format!("{}/{}", project_directory, project_name);
+    if Path::new(&project_path).exists() {
+        // Remove the important files for an overwrite
+        println!("📝 {}Found that project already exists. Overwriting it.{}", FM::light_blue, FM::reset);
+        if Path::new(&format!("{}/Preview.png", project_path)).exists() { remove_file(format!("{}/Preview.png", project_path))?; }
+        if Path::new(&format!("{}/Vehicle.brv", project_path)).exists() { remove_file(format!("{}/Vehicle.brv", project_path))?; }
+        if Path::new(&format!("{}/Vehicle.brm", project_path)).exists() { remove_file(format!("{}/Vehicle.brm", project_path))?; }
+    } else { // Directory doesn't already exist, create it
+        create_dir_all(&project_path)?;
+    }
+    write_brv(&project_path)?;
+    write_brm(&project_path)?;
     write_preview(&project_path)?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@ mod handler;
 #[allow(unused_imports)]
 use to_binary::{BinaryString,BinaryError};
 #[macro_use] mod misc;
-use misc::{FM/*, FM::**/}; // The glob operator can be used but is dangerous if you do not know what you are doing.
+use misc::FM; // The glob operator can be used but is dangerous if you do not know what you are doing.
 
-const VERSION: &str = "V0.3.0";
+const VERSION: &str = "V0.3.7";
 
 /* Semantic versioning.
 Scheme goes like this:
@@ -15,7 +15,7 @@ Third number: Smaller update, usually a hotfix or patch */
 
 fn main() {
     printlnr!("\n✨ {}Welcome to BRCI.rs!", FM::light_green);
-    printlnr!("{}📋Program version: [{VERSION}]\n", FM::light_blue);
+    printlnr!("📋 {}Program version: [{VERSION}]\n", FM::light_blue);
     
     // It is my belief that this structure shouldn't be used. Not in the current state.
     /* #[allow(dead_code)]
@@ -33,6 +33,16 @@ fn main() {
         
     }
     */
-    #[allow(unused_variables)]
-    let make_proj_result = handler::make_project("Test", "Projects");
+    let project_name: &str = "Test";
+    let project_dir: &str = "Projects";
+    let make_proj_result = match handler::make_project(project_name, project_dir) {
+        Ok(_) => "Success".to_string(),
+        Err(val) => val.to_string(),
+    };
+
+    if make_proj_result == "Success" {
+        printlnr!("✅ {}Project created successfully!", FM::light_green);
+    } else {
+        printlnr!("❌ {}Failed to create project!\n'{}'", FM::light_red, make_proj_result);
+    }
 }

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -47,12 +47,12 @@ pub mod FM {
     pub const bg_light_purple: &str = "\x1b[105m";
     pub const bg_cyan: &str = "\x1b[46m";
     pub const bg_light_cyan: &str = "\x1b[106m";
-    pub const info: &str = "{reverse}{light_blue}[,INFO]{remove_reverse}";
-    pub const success: &str = "{reverse}{light_gre,en}[SUCCESS]{remove_reverse}";
+    //pub const info: &str = "{reverse}{light_blue}[,INFO]{remove_reverse}";
+    //pub const success: &str = "{reverse}{light_gre,en}[SUCCESS]{remove_reverse}";
  // pub const error: &str = f"{reverse}{light_red,}[ERROR]";
-    pub const warning: &str = "{reverse}{light_red}[WARNING]";
-    pub const debug: &str = "{reverse}{light_purple}[DEBUG]{remove_reverse}";
-    pub const testfm: &str = "{reverse}{light_cyan}[TEST]{remove_reverse}";
+    //pub const warning: &str = "{reverse}{light_red}[WARNING]";
+    //pub const debug: &str = "{reverse}{light_purple}[DEBUG]{remove_reverse}";
+    //pub const testfm: &str = "{reverse}{light_cyan}[TEST]{remove_reverse}";
 }
 
 


### PR DESCRIPTION
- handler::make_project() now overwrites the project if it exists
- main.rs example generation now prints the result out
- updated .gitignore to ignore everything in the Projects directory, but this is commented out and not in effect yet
- Updated Cargo.lock to match 0.3.7
- Commented out some variables within misc::FM
- Updated handler.rs to have handler::write_brm(), handler::write_brv() has been updated to have an argument like it

This was an absolute doozy. Github Desktop (which I just started using) really hated the idea of me existing (quite literally, it complained about something along the lines of that)